### PR TITLE
[feat] sms 인증번호 요청 및 인증 하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//sms
+	implementation 'net.nurigo:javaSDK:2.2'
+	implementation "org.springframework.boot:spring-boot-starter-data-redis"
 }
 
 tasks.named('test') {

--- a/src/main/java/gdg/festa/application/service/SmsCertifyService.java
+++ b/src/main/java/gdg/festa/application/service/SmsCertifyService.java
@@ -1,0 +1,30 @@
+package gdg.festa.application.service;
+
+import gdg.festa.application.usecase.sms.SmsCertifyUseCase;
+import gdg.festa.core.exception.CustomException;
+import gdg.festa.core.exception.ErrorCode;
+import gdg.festa.core.util.SmsUtil;
+import gdg.festa.infrastructure.redis.SmsCertification;
+import gdg.festa.presentation.request.SmsCertifyRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SmsCertifyService implements SmsCertifyUseCase {
+    private final SmsUtil smsUtil;
+    private final SmsCertification smsCertification;
+
+    public Boolean execute(SmsCertifyRequestDto smsCertifyRequestDto) {
+        String phone = smsCertifyRequestDto.phoneNumber();
+        String code = smsUtil.sendSMS(phone);;
+        if(code.isEmpty()){
+            throw new CustomException(ErrorCode.SMS_SEND_FAIL);
+        }
+        smsCertification.createSmsCertification(phone, code);
+
+        return true;
+    }
+}

--- a/src/main/java/gdg/festa/application/service/SmsVertifyService.java
+++ b/src/main/java/gdg/festa/application/service/SmsVertifyService.java
@@ -1,0 +1,35 @@
+package gdg.festa.application.service;
+
+import gdg.festa.application.usecase.sms.SmsVertifyUseCase;
+import gdg.festa.core.exception.CustomException;
+import gdg.festa.core.exception.ErrorCode;
+import gdg.festa.infrastructure.redis.SmsCertification;
+import gdg.festa.presentation.request.SmsVerifyRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SmsVertifyService implements SmsVertifyUseCase {
+
+    private SmsCertification smsCertification;
+
+    @Override
+    public Boolean execute(SmsVerifyRequestDto smsVerifyRequestDto) {
+        if (isVerify(smsVerifyRequestDto)) {
+            throw new CustomException(ErrorCode.SMS_VERIFY_FAILED);
+        }
+        smsCertification.deleteSmsCertification(smsVerifyRequestDto.phoneNumber());
+
+        return true;
+    }
+
+
+    private boolean isVerify(SmsVerifyRequestDto smsVerifyRequestDto) {
+        return !(smsCertification.hasKey(smsVerifyRequestDto.phoneNumber()) &&
+                smsCertification.getSmsCertification(smsVerifyRequestDto.phoneNumber())
+                        .equals(smsVerifyRequestDto.certificationNumber()));
+    }
+}

--- a/src/main/java/gdg/festa/application/usecase/sms/SmsCertifyUseCase.java
+++ b/src/main/java/gdg/festa/application/usecase/sms/SmsCertifyUseCase.java
@@ -1,0 +1,9 @@
+package gdg.festa.application.usecase.sms;
+
+import gdg.festa.core.annotation.UseCase;
+import gdg.festa.presentation.request.SmsCertifyRequestDto;
+
+@UseCase
+public interface SmsCertifyUseCase {
+    Boolean execute(SmsCertifyRequestDto smsCertifyRequestDto);
+}

--- a/src/main/java/gdg/festa/application/usecase/sms/SmsVertifyUseCase.java
+++ b/src/main/java/gdg/festa/application/usecase/sms/SmsVertifyUseCase.java
@@ -1,0 +1,9 @@
+package gdg.festa.application.usecase.sms;
+
+import gdg.festa.core.annotation.UseCase;
+import gdg.festa.presentation.request.SmsVerifyRequestDto;
+
+@UseCase
+public interface SmsVertifyUseCase {
+    Boolean execute(SmsVerifyRequestDto smsVerifyRequestDto);
+}

--- a/src/main/java/gdg/festa/core/config/RedisConfig.java
+++ b/src/main/java/gdg/festa/core/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package gdg.festa.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // 일반적인 key:value의 경우 시리얼라이저
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+//        // Hash를 사용할 경우 시리얼라이저
+//        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+//
+//        // 모든 경우
+//        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/gdg/festa/core/constant/Constants.java
+++ b/src/main/java/gdg/festa/core/constant/Constants.java
@@ -27,6 +27,7 @@ public final class Constants {
             "/api/v1/auth/admin/login",
             "/admin/login/register",
             "/admin/login/**",
+            "/sms/**",
             "/ws",
             "/ws-stomp",
             "/ws-stomp/**",

--- a/src/main/java/gdg/festa/core/exception/ErrorCode.java
+++ b/src/main/java/gdg/festa/core/exception/ErrorCode.java
@@ -41,7 +41,7 @@ public enum ErrorCode {
     INVALID_APPLE_PUBLIC_KEY_ERROR("40108", HttpStatus.UNAUTHORIZED, "잘못된 Apple 공개키입니다."),
     INVALID_LOGIN_TYPE("40109", HttpStatus.UNAUTHORIZED, "잘못된 로그인 요청입니다."),
     INVALID_PASSWORD("40110", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다. "),
-
+    SMS_VERIFY_FAILED("40111", HttpStatus.UNAUTHORIZED, "휴대전화 인증 실패"),
     /**
      * 403** Access Denied
      */
@@ -79,6 +79,7 @@ public enum ErrorCode {
      * 500** Server Error
      */
     SERVER_ERROR("50000", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    SMS_SEND_FAIL("50102", HttpStatus.INTERNAL_SERVER_ERROR, "메세지 전송 실패"),
     EXTERNAL_SERVER_ERROR("50101", HttpStatus.INTERNAL_SERVER_ERROR, "서버 외부 오류");
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/gdg/festa/core/util/SmsUtil.java
+++ b/src/main/java/gdg/festa/core/util/SmsUtil.java
@@ -1,0 +1,65 @@
+package gdg.festa.core.util;
+
+import gdg.festa.core.exception.CustomException;
+import gdg.festa.core.exception.ErrorCode;
+import java.util.HashMap;
+import java.util.Random;
+import net.nurigo.java_sdk.exceptions.CoolsmsException;
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import net.nurigo.java_sdk.api.Message;
+
+@Service
+public class SmsUtil {
+    // private final SmsCertification smsCertification;
+
+    @Value("${coolsms.apikey}")
+    private String apiKey;
+
+    @Value("${coolsms.apisecret}")
+    private String apiSecret;
+
+    @Value("${coolsms.fromnumber}")
+    private String fromNumber;
+
+    private String createRandomNumber() {
+        Random rand = new Random();
+        String randomNum = "";
+        for (int i = 0; i < 4; i++) {
+            String random = Integer.toString(rand.nextInt(10));
+            randomNum += random;
+        }
+        return randomNum;
+    }
+
+    private HashMap<String, String> makeParams(String to, String randomNum) {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("from", fromNumber);
+        params.put("type", "SMS");
+        params.put("app_version", "test app 1.2");
+        params.put("to", to);
+        params.put("text", "인증 번호 : " + randomNum);
+        return params;
+    }
+
+    // 인증번호 전송하기
+    public String sendSMS(String phonNumber) {
+        Message coolsms = new Message(apiKey, apiSecret);
+
+        // 랜덤한 인증 번호 생성
+        String randomNum = createRandomNumber();
+
+        // 발신 정보 설정
+        HashMap<String, String> params = makeParams(phonNumber, randomNum);
+
+        try {
+            JSONObject obj = (JSONObject) coolsms.send(params);
+        } catch (CoolsmsException e) {
+            throw new CustomException(ErrorCode.SMS_SEND_FAIL);
+        }
+
+        return randomNum;
+    }
+}
+

--- a/src/main/java/gdg/festa/infrastructure/redis/SmsCertification.java
+++ b/src/main/java/gdg/festa/infrastructure/redis/SmsCertification.java
@@ -1,0 +1,35 @@
+package gdg.festa.infrastructure.redis;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class SmsCertification {
+    private final String PREFIX = "sms:"; // key값이 중복되지 않도록 상수 선언
+    private final int LIMIT_TIME = 100 * 60; // 인증번호 유효 시간
+    private final StringRedisTemplate stringRedisTemplate;
+
+    // Redis에 저장
+    public void createSmsCertification(String phone, String certificationNumber) {
+        stringRedisTemplate.opsForValue()
+                .set(PREFIX + phone, certificationNumber, Duration.ofSeconds(LIMIT_TIME));
+    }
+
+    // 휴대전화 번호에 해당하는 인증번호 불러오기
+    public String getSmsCertification(String phone) {
+        return stringRedisTemplate.opsForValue().get(PREFIX + phone);
+    }
+
+    // 인증 완료 시, 인증번호 Redis에서 삭제
+    public void deleteSmsCertification(String phone) {
+        stringRedisTemplate.delete(PREFIX + phone);
+    }
+
+    // Redis에 해당 휴대번호로 저장된 인증번호가 존재하는지 확인
+    public boolean hasKey(String phone) {
+        return stringRedisTemplate.hasKey(PREFIX + phone);
+    }
+}

--- a/src/main/java/gdg/festa/presentation/controller/SmsController.java
+++ b/src/main/java/gdg/festa/presentation/controller/SmsController.java
@@ -1,0 +1,34 @@
+package gdg.festa.presentation.controller;
+
+import gdg.festa.application.usecase.sms.SmsCertifyUseCase;
+import gdg.festa.application.usecase.sms.SmsVertifyUseCase;
+import gdg.festa.core.common.CommonResponseDto;
+import gdg.festa.presentation.request.SmsCertifyRequestDto;
+import gdg.festa.presentation.request.SmsVerifyRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/sms")
+@RequiredArgsConstructor
+public class SmsController {
+    private final SmsCertifyUseCase smsCertifyUseCase;
+    private final SmsVertifyUseCase smsVertifyUseCase;
+
+    @PostMapping("/verify")
+    public CommonResponseDto<?> verify(
+            @RequestBody SmsVerifyRequestDto smsVerifyRequestDto
+    ) {
+        return CommonResponseDto.ok(smsVertifyUseCase.execute(smsVerifyRequestDto));
+    }
+
+    @PostMapping("/certify")
+    public CommonResponseDto<?> certify(
+            @RequestBody SmsCertifyRequestDto smsCertifyRequestDto
+    ) {
+        return CommonResponseDto.ok(smsCertifyUseCase.execute(smsCertifyRequestDto));
+    }
+}

--- a/src/main/java/gdg/festa/presentation/request/SmsCertifyRequestDto.java
+++ b/src/main/java/gdg/festa/presentation/request/SmsCertifyRequestDto.java
@@ -1,0 +1,6 @@
+package gdg.festa.presentation.request;
+
+public record SmsCertifyRequestDto(
+        String phoneNumber
+) {
+}

--- a/src/main/java/gdg/festa/presentation/request/SmsVerifyRequestDto.java
+++ b/src/main/java/gdg/festa/presentation/request/SmsVerifyRequestDto.java
@@ -1,0 +1,7 @@
+package gdg.festa.presentation.request;
+
+public record SmsVerifyRequestDto(
+        String phoneNumber,
+        String certificationNumber
+) {
+}


### PR DESCRIPTION
## ✨ Related Issues
- Resolves: #7 

## 📌 Tasks
 - 사용자의 번호가 본인의 번호인지를 확인하고자 sms 인증을 도입
 - 인증 번호를 상수 시간으로 redis의 Key value로 저장하여 다음 인증 요청이 들어왔을때 전화번호를 통해 인증번호 match를 판단한다.

