### PR TITLE
[feat] #28 LostImage 레포 및 엔티티 수정

### DIFF
--- a/src/main/java/gdg/festa/application/mapper/LostsImageMapper.java
+++ b/src/main/java/gdg/festa/application/mapper/LostsImageMapper.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class LostsImageMapper {
 
     public LostImages toEntity(String imagesUrl,Losts losts){
-        return LostImages.builder()
+        return LostImages.LostImagesBuilder()
                 .losts(losts)
                 .imageUrl(imagesUrl)
                 .build();

--- a/src/main/java/gdg/festa/application/mapper/LostsMapper.java
+++ b/src/main/java/gdg/festa/application/mapper/LostsMapper.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class LostsMapper {
 
     public Losts toEntity(LostsRequestDto lostsRequestDto) {
-        return Losts.builder()
+        return Losts.LostsBuilder()
                 .title(lostsRequestDto.title())
                 .color(lostsRequestDto.color())
                 .brand(lostsRequestDto.brand())

--- a/src/main/java/gdg/festa/application/service/Losts/EditLostsService.java
+++ b/src/main/java/gdg/festa/application/service/Losts/EditLostsService.java
@@ -34,12 +34,13 @@ public class EditLostsService implements EditLostsUsecase {
     public void execute(Long lostsId, LostsRequestDto lostsRequestDto) {
         Losts losts = lostsRepository.findById(lostsId);
 
-        losts.setLosts(lostsRequestDto); // setLosts 메서드는 엔티티 내부에 정의되어 있어야 함
+        losts.setLosts(lostsRequestDto);
 
-        List<LostImages> oldImages = lostImageRepository.findByLosts(losts);
-        lostImageRepository.deleteByLosts(losts);
+        List<LostImages> oldImages = lostImageRepository.findByLostsAndDeletedAtIsNull(losts);
+        oldImages.forEach(img -> {
+            img.delete();  // deletedAt = now()
 
-        oldImages.forEach(img -> s3Util.delete(img.getImageUrl()));
+        });
 
         List<String> imageUrls = s3Util.upload(lostsRequestDto.images());
 

--- a/src/main/java/gdg/festa/application/service/Losts/RemoveLostService.java
+++ b/src/main/java/gdg/festa/application/service/Losts/RemoveLostService.java
@@ -1,10 +1,15 @@
 package gdg.festa.application.service.Losts;
 
 import gdg.festa.application.usecase.Losts.RemoveLostsUsecase;
+import gdg.festa.domain.entity.LostImages;
+import gdg.festa.domain.entity.Losts;
+import gdg.festa.domain.repository.LostImageRepository;
 import gdg.festa.domain.repository.LostsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -12,9 +17,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class RemoveLostService implements RemoveLostsUsecase {
 
     private final LostsRepository lostsRepository;
+    private final LostImageRepository lostImageRepository;
 
     @Override
     public void execute(Long lostsId){
-        lostsRepository.deleteById(lostsId);
+        Losts getLost = lostsRepository.findById(lostsId);
+
+        // 관련 이미지들도 Soft Delete
+        List<LostImages> lostImages = lostImageRepository.findByLostsAndDeletedAtIsNull(getLost);
+        for (LostImages image : lostImages) {
+            image.delete(); // deletedAt에 시간 설정
+        }
+
+        // Losts 자체도 Soft Delete
+        getLost.delete(); // deletedAt = now()
     }
 }

--- a/src/main/java/gdg/festa/domain/entity/LostImages.java
+++ b/src/main/java/gdg/festa/domain/entity/LostImages.java
@@ -17,13 +17,13 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
+@Builder(builderMethodName = "LostImagesBuilder")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "lost_images")
-public class LostImages {
+public class LostImages extends BaseEntity {
     @Id
-    @Column(name = "lostImages_id")
+    @Column(name = "lost_images_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long lostImagesId;
 
@@ -31,6 +31,6 @@ public class LostImages {
     @JoinColumn(name = "losts_id")
     private Losts losts;
 
-    @Column(name = "lostImages_image_url")
+    @Column(name = "lost_images_image_url")
     private String imageUrl;
 }

--- a/src/main/java/gdg/festa/domain/entity/Losts.java
+++ b/src/main/java/gdg/festa/domain/entity/Losts.java
@@ -8,10 +8,10 @@ import lombok.*;
 @Entity
 @Getter
 @AllArgsConstructor
-@Builder
+@Builder(builderMethodName = "LostsBuilder")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "losts")
-public class Losts {
+public class Losts extends BaseEntity {
     @Id
     @Column(name = "losts_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/gdg/festa/domain/repository/LostImageRepository.java
+++ b/src/main/java/gdg/festa/domain/repository/LostImageRepository.java
@@ -11,4 +11,5 @@ public interface LostImageRepository {
     List<LostImages> findByLostsLostsId(Long lostsId);
     List<LostImages> findByLosts(Losts losts);
     void deleteByLosts(Losts losts);
+    List<LostImages> findByLostsAndDeletedAtIsNull(Losts losts);
 }

--- a/src/main/java/gdg/festa/infrastructure/implement/LostImageRepositoryImpl.java
+++ b/src/main/java/gdg/festa/infrastructure/implement/LostImageRepositoryImpl.java
@@ -36,4 +36,9 @@ public class LostImageRepositoryImpl implements LostImageRepository {
     public void deleteByLosts(Losts losts){
         lostsImageJpaRepository.deleteByLosts(losts);
     }
+
+    @Override
+    public List<LostImages> findByLostsAndDeletedAtIsNull(Losts losts) {
+        return lostsImageJpaRepository.findByLostsAndDeletedAtIsNull(losts);
+    }
 }

--- a/src/main/java/gdg/festa/infrastructure/jpa/LostImageJpaRepository.java
+++ b/src/main/java/gdg/festa/infrastructure/jpa/LostImageJpaRepository.java
@@ -17,4 +17,6 @@ public interface LostImageJpaRepository extends JpaRepository<LostImages,Long> {
     @Modifying
     @Query("DELETE FROM LostImages li WHERE li.losts = :losts")
     void deleteByLosts(@Param("losts") Losts losts);
+
+    List<LostImages> findByLostsAndDeletedAtIsNull(Losts losts);
 }


### PR DESCRIPTION
## ✨ Related Issues
- Resolves:

## 📌 Tasks
앤티티
- DB 이름 수정
- Builder 이름 LostImagesBuilder 수정
- BaseEntity 상속

레포
- Soft Delete 메서드 제작

## 💬 Additional Notes
삭제시 BaseEntity 사용하도록 제작
