### PR TITLE
[Fix] FcmError Fix

### DIFF
--- a/src/main/java/gdg/festa/application/service/reserve/CompleteReserveService.java
+++ b/src/main/java/gdg/festa/application/service/reserve/CompleteReserveService.java
@@ -38,6 +38,11 @@ public class CompleteReserveService implements CompleteReserveUseCase {
         PubAdmin pubAdmin = pubAdminRepository.findById(adminId);
 
         List<Reserve> nextReserve = reserveRepository.findByPubsAndReserveStatus(pubAdmin.getPub());
+
+        if (nextReserve.isEmpty()){
+            return true;
+        }
+
         //fcm 근처에서 대기하십쇼
         nextReserve.forEach(
                 reserves1 -> fcmUtil.sendMessage(


### PR DESCRIPTION
## ✨ Related Issues
- Resolves:

## 📌 Tasks
대기자가 1명인 경우, 해당 대기자를 관리자가 호출한 경우, 다음 대기자에게 Fcm알람 보낼때 빈 리스트가 조회되어 NPE문제 발생. 
빈 리스트일 경우 서비스 로직 종료.


